### PR TITLE
Rename Keycloak dependency to repository name

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
   angular_router: ^2.0.0-alpha+21
 
   keycloak:
-    path: "../keycloak-dart"
+    path: "../keycloak"
 
 dev_dependencies:
   build_runner: ^1.5.2


### PR DESCRIPTION
The repository and package name for the keycloak bindings have been renamed to `keycloak` from `keycloak-dart`. This package referenced the old keycloak package name `keycloak-dart` in the package definition. Now the new package name `keycloak` is used.