### PR TITLE
Angular6.0.0 keycloak

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -7,6 +7,7 @@ targets:
       - lib/**
       - test/**
       # Note that it is important to include these in the default target.
+      - $package$
       - pubspec.*
     builders:
       build_web_compilers|entrypoint:

--- a/example-directive/app/example_app_component.dart
+++ b/example-directive/app/example_app_component.dart
@@ -45,6 +45,11 @@ class ExampleAppComponent implements OnInit {
     }
   }
 
+  List<String> bossRole = ['boss'];
+  List<String> supervisorRole = ['supervisor'];
+  List<String> memberRole = ['member'];
+  List<String> vipRole = ['vip'];
+
   void loginCustomer() {
     _login(customerInstanceId);
   }

--- a/example-directive/app/example_app_component.html
+++ b/example-directive/app/example_app_component.html
@@ -33,12 +33,12 @@
       <h3>Employee Corner</h3>
 
       <!-- The following div will only show for user with 'boss' roles -->
-      <div *kcSecurity="roles: ['boss']">
+      <div *kcSecurity="roles: bossRole">
         <p>Welcome back boss, only you can see this.</p>
       </div>
 
       <!-- Contrary to above, this only show for user without 'boss' roles -->
-      <div *kcSecurity="showWhenDenied: true; roles: ['boss']">
+      <div *kcSecurity="showWhenDenied: true; roles: bossRole">
         <p>Hurry up and work!</p>
       </div>
 
@@ -46,7 +46,7 @@
            There's one different, for user with only 'supervisor' role,
            the variable of 'readonly' will be true. -->
       <div
-        *kcSecurity="readonlyRoles: ['supervisor']; roles: ['boss']; let ro = readonly"
+        *kcSecurity="readonlyRoles: supervisorRole; roles: bossRole; let ro = readonly"
       >
         <h3>This Year Bonus</h3>
         Supervisor can see. Boss can change.
@@ -68,8 +68,8 @@
     <div
       *kcSecurity="
         customerInstanceId;
-        readonlyRoles: ['member'];
-        roles: ['vip'];
+        readonlyRoles: memberRole;
+        roles: vipRole;
         let ro = readonly
       "
     >

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,17 +6,17 @@ environment:
   sdk: ">=2.2.0 <3.0.0"
 
 dependencies:
-  angular: ^6.0.0-alpha+1
-  angular_router: ^2.0.0-alpha+22
+  angular: ^6.0.0
+  angular_router: ^2.0.0
 
   keycloak:
     git: https://github.com/itbh-at/keycloak.git
 
 dev_dependencies:
-  angular_components: ^0.14.0-alpha+1
-  angular_test: ^2.3.0
-  build_runner: ^1.6.5
-  build_test: ^0.10.8
-  build_web_compilers: ^2.3.0
-  mockito: ^4.1.0
-  test: ^1.6.3
+  angular_components: ^1.0.2
+  angular_test: ^3.0.0
+  build_runner: ^1.10.2
+  build_test: ^1.2.2
+  build_web_compilers: ^2.11.0
+  mockito: ^4.1.2
+  test: ^1.15.4

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,17 +6,17 @@ environment:
   sdk: ">=2.2.0 <3.0.0"
 
 dependencies:
-  angular: ^5.3.1
-  angular_router: ^2.0.0-alpha+21
+  angular: ^6.0.0-alpha+1
+  angular_router: ^2.0.0-alpha+22
 
   keycloak:
     git: https://github.com/itbh-at/keycloak.git
 
 dev_dependencies:
-  angular_components: ^0.13.0+1
+  angular_components: ^0.14.0-alpha+1
   angular_test: ^2.3.0
   build_runner: ^1.6.5
   build_test: ^0.10.8
-  build_web_compilers: ^1.2.2
+  build_web_compilers: ^2.3.0
   mockito: ^4.1.0
   test: ^1.6.3

--- a/test/security_directive_test.dart
+++ b/test/security_directive_test.dart
@@ -169,14 +169,18 @@ class SingleInstanceAuthenticationComponent {}
 class MultipleInstanceAuthenticationComponent {}
 
 @Component(selector: 'test-security', directives: [KcSecurity], template: '''
-  <p *kcSecurity="roles:['boss']">the boss</p>
-  <p *kcSecurity="roles:['reader', 'writer']; 
-                  readonlyRoles:['reader']; 
+  <p *kcSecurity="roles:bossRole">the boss</p>
+  <p *kcSecurity="roles:readerWriterRole; 
+                  readonlyRoles:readerRole; 
                   let ro=readonly">
     can read; {{ro ? 'cannot' : 'can'}} write
   </p>
   ''')
-class RoleAuthorizationComponent {}
+class RoleAuthorizationComponent {
+  List<String> bossRole = ['boss'];
+  List<String> readerRole = ['reader'];
+  List<String> readerWriterRole = ['reader', 'writer'];
+}
 
 @Injectable()
 class MockKeycloakService extends Mock implements KeycloakService {}


### PR DESCRIPTION
- Upgrade `angular` package to the official 6.0.0 release.
- Fix up the `List` used in the template, it is not allow now in the latest release.
